### PR TITLE
Adding voucher number and payment description to all loan repayments, savings deposits and withdrawls

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
@@ -122,6 +122,7 @@ public class JournalEntryReadPlatformServiceImpl implements JournalEntryReadPlat
                 sb.append(" ,pd.receipt_number as receiptNumber, ").append(" pd.check_number as checkNumber, ")
                         .append(" pd.account_number as accountNumber, ").append(" pt.value as paymentTypeName, ")
                         .append(" pd.payment_type_id as paymentTypeId,").append(" pd.bank_number as bankNumber, ")
+                        .append(" pd.voucher_number as voucherNumber,").append(" pd.payment_description as paymentDescription, ")
                         .append(" pd.routing_code as routingCode, ").append(" note.id as noteId, ")
                         .append(" note.note as transactionNote, ").append(" lt.transaction_type_enum as loanTransactionType, ")
                         .append(" st.transaction_type_enum as savingsTransactionType ");
@@ -203,9 +204,11 @@ public class JournalEntryReadPlatformServiceImpl implements JournalEntryReadPlat
                     final String checkNumber = rs.getString("checkNumber");
                     final String routingCode = rs.getString("routingCode");
                     final String receiptNumber = rs.getString("receiptNumber");
-                    final String bankNumber = rs.getString("bankNumber");
+                    final String bankNumber = rs.getString("bankNumber"); 
+                    final String voucherNumber = rs.getString("voucherNumber");
+                    final String paymentDescription = rs.getString("paymentDescription");
                     paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                            bankNumber);
+                            bankNumber,voucherNumber,paymentDescription);
                 }
                 NoteData noteData = null;
                 final Long noteId = JdbcSupport.getLong(rs, "noteId");

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientApiConstants.java
@@ -118,7 +118,9 @@ public class ClientApiConstants {
     public static final String checkNumberParamName = "checkNumber";
     public static final String routingCodeParamName = "routingCode";
     public static final String receiptNumberParamName = "receiptNumber";
-    public static final String bankNumberParamName = "bankNumber";
+    public static final String bankNumberParamName = "bankNumber"; 
+    public static final String voucherNumberParamName = "voucherNumber";
+    public static final String paymentDescriptionParamName = "paymentDescription";
     
     //request parameters for client non person
     public static final String clientNonPersonDetailsParamName = "clientNonPersonDetails";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientApiCollectionConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientApiCollectionConstants.java
@@ -80,7 +80,7 @@ public class ClientApiCollectionConstants extends ClientApiConstants{
 
     protected static final Set<String> CLIENT_CHARGES_PAY_CHARGE_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(amountParamName,
             transactionDateParamName, dateFormatParamName, localeParamName, paymentTypeIdParamName, transactionAccountNumberParamName,
-            checkNumberParamName, routingCodeParamName, receiptNumberParamName, bankNumberParamName));
+            checkNumberParamName, routingCodeParamName, receiptNumberParamName, bankNumberParamName,voucherNumberParamName,paymentDescriptionParamName));
 
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientTransactionReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientTransactionReadPlatformServiceImpl.java
@@ -121,7 +121,7 @@ public class ClientTransactionReadPlatformServiceImpl implements ClientTransacti
                     final String paymentDescription = rs.getString("paymentDescription");
 
                     paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                            bankNumber,voucherNumber,paymentDescriptioin);
+                            bankNumber.voucherNumber.paymentDescriptioin);
                 }
             }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientTransactionReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientTransactionReadPlatformServiceImpl.java
@@ -121,7 +121,7 @@ public class ClientTransactionReadPlatformServiceImpl implements ClientTransacti
                     final String paymentDescription = rs.getString("paymentDescription");
 
                     paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                            bankNumber.voucherNumber.paymentDescriptioin);
+                            bankNumber, voucherNumber, paymentDescription);
                 }
             }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientTransactionReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientTransactionReadPlatformServiceImpl.java
@@ -71,6 +71,8 @@ public class ClientTransactionReadPlatformServiceImpl implements ClientTransacti
             sqlBuilder.append("c.id as clientId, c.account_no as accountNo, ccpb.client_charge_id as clientChargeId, ");
             sqlBuilder.append("pd.payment_type_id as paymentType,pd.account_number as accountNumber,pd.check_number as checkNumber, ");
             sqlBuilder.append("pd.receipt_number as receiptNumber, pd.bank_number as bankNumber,pd.routing_code as routingCode,  ");
+            sqlBuilder.append("pd.voucher_number as voucherNumber, pd.payment_description as paymentDescription,  ");
+
             sqlBuilder.append(
                     "tr.currency_code as currencyCode, curr.decimal_places as currencyDigits, curr.currency_multiplesof as inMultiplesOf, ");
             sqlBuilder.append("curr.name as currencyName, curr.internationalized_name_code as currencyNameCode,  ");
@@ -115,8 +117,11 @@ public class ClientTransactionReadPlatformServiceImpl implements ClientTransacti
                     final String routingCode = rs.getString("routingCode");
                     final String receiptNumber = rs.getString("receiptNumber");
                     final String bankNumber = rs.getString("bankNumber");
+                    final String voucherNumber = rs.getString("voucherNumber");
+                    final String paymentDescription = rs.getString("paymentDescription");
+
                     paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                            bankNumber);
+                            bankNumber,voucherNumber,paymentDescriptioin);
                 }
             }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collectionsheet/data/CollectionSheetTransactionDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collectionsheet/data/CollectionSheetTransactionDataValidator.java
@@ -62,7 +62,7 @@ public class CollectionSheetTransactionDataValidator {
             CollectionSheetConstants.bulkSavingsDueTransactionsParamName, PaymentDetailConstants.paymentTypeParamName,
             PaymentDetailConstants.accountNumberParamName, PaymentDetailConstants.checkNumberParamName,
             PaymentDetailConstants.routingCodeParamName, PaymentDetailConstants.receiptNumberParamName,
-            PaymentDetailConstants.bankNumberParamName, CollectionSheetConstants.isTransactionDateOnNonMeetingDateParamName));
+            PaymentDetailConstants.bankNumberParamName, PaymentDetailConstants.voucherNumberParamName,PaymentDetailConstants.paymentDescriptionParamName, CollectionSheetConstants.isTransactionDateOnNonMeetingDateParamName));
 
 	private static final Set<String> INDIVIDUAL_COLLECTIONSHEET_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(
 			CollectionSheetConstants.localeParamName, CollectionSheetConstants.dateFormatParamName,
@@ -74,7 +74,7 @@ public class CollectionSheetTransactionDataValidator {
 	private static final Set<String> PAYMENT_CREATE_REQUEST_DATA_PARAMETERS = new HashSet<>(
 			Arrays.asList(PaymentDetailConstants.accountNumberParamName, PaymentDetailConstants.checkNumberParamName,
 					PaymentDetailConstants.routingCodeParamName, PaymentDetailConstants.receiptNumberParamName,
-					PaymentDetailConstants.bankNumberParamName));
+					PaymentDetailConstants.bankNumberParamName,PaymentDetailConstants.voucherNumberParamName,PaymentDetailConstants.paymentDescriptionParamName));
 
     @Autowired
     public CollectionSheetTransactionDataValidator(final FromJsonHelper fromApiJsonHelper) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanEventApiJsonValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanEventApiJsonValidator.java
@@ -77,7 +77,8 @@ public final class LoanEventApiJsonValidator {
                     "dateFormat", LoanApiConstants.principalDisbursedParameterName, LoanApiConstants.emiAmountParameterName));
         } else {
             disbursementParameters = new HashSet<>(Arrays.asList("actualDisbursementDate", "externalId", "note", "locale",
-                    "dateFormat", "paymentTypeId", "accountNumber", "checkNumber", "routingCode", "receiptNumber", "bankNumber", "adjustRepaymentDate", 
+                    "dateFormat", "paymentTypeId", "accountNumber", "checkNumber", "routingCode", "receiptNumber", "bankNumber", "adjustRepaymentDate",
+                    "voucherNumber","paymentDescription" 
                     LoanApiConstants.principalDisbursedParameterName, LoanApiConstants.emiAmountParameterName));
         }
 
@@ -129,7 +130,7 @@ public final class LoanEventApiJsonValidator {
 
         final Set<String> transactionParameters = new HashSet<>(Arrays.asList("transactionDate", "transactionAmount", "externalId",
                 "note", "locale", "dateFormat", "paymentTypeId", "accountNumber", "checkNumber", "routingCode", "receiptNumber",
-                "bankNumber"));
+                "bankNumber","voucherNumber","paymentDescription"));
 
         final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
         this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, transactionParameters);
@@ -157,7 +158,7 @@ public final class LoanEventApiJsonValidator {
 
         final Set<String> transactionParameters = new HashSet<>(Arrays.asList("transactionDate", "transactionAmount", "externalId",
                 "note", "locale", "dateFormat", "paymentTypeId", "accountNumber", "checkNumber", "routingCode", "receiptNumber",
-                "bankNumber"));
+                "bankNumber","voucherNumber","paymentDescription"));
 
         final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
         this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, transactionParameters);
@@ -199,7 +200,7 @@ public final class LoanEventApiJsonValidator {
         final Integer paymentTypeId = this.fromApiJsonHelper.extractIntegerWithLocaleNamed("paymentTypeId", element);
         baseDataValidator.reset().parameter("paymentTypeId").value(paymentTypeId).ignoreIfNull().integerGreaterThanZero();
         final Set<String> paymentDetailParameters = new HashSet<>(Arrays.asList("accountNumber", "checkNumber", "routingCode",
-                "receiptNumber", "bankNumber"));
+                "receiptNumber", "bankNumber","voucherNumber","paymentDescription"));
         for (final String paymentDetailParameterName : paymentDetailParameters) {
             final String paymentDetailParameterValue = this.fromApiJsonHelper.extractStringNamed(paymentDetailParameterName, element);
             baseDataValidator.reset().parameter(paymentDetailParameterName).value(paymentDetailParameterValue).ignoreIfNull()
@@ -425,7 +426,7 @@ public final class LoanEventApiJsonValidator {
 
         final Set<String> transactionParameters = new HashSet<>(Arrays.asList("transactionDate", "transactionAmount", "externalId",
                 "note", "locale", "dateFormat", "paymentTypeId", "accountNumber", "checkNumber", "routingCode", "receiptNumber",
-                "bankNumber"));
+                "bankNumber","voucherNumber","paymentDescription"));
 
         final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
         this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, transactionParameters);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanEventApiJsonValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanEventApiJsonValidator.java
@@ -78,7 +78,7 @@ public final class LoanEventApiJsonValidator {
         } else {
             disbursementParameters = new HashSet<>(Arrays.asList("actualDisbursementDate", "externalId", "note", "locale",
                     "dateFormat", "paymentTypeId", "accountNumber", "checkNumber", "routingCode", "receiptNumber", "bankNumber", "adjustRepaymentDate",
-                    "voucherNumber","paymentDescription" 
+                    "voucherNumber","paymentDescription", 
                     LoanApiConstants.principalDisbursedParameterName, LoanApiConstants.emiAmountParameterName));
         }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -1262,6 +1262,7 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
                     + " tr.manually_adjusted_or_reversed as manuallyReversed, "
                     + " pd.payment_type_id as paymentType,pd.account_number as accountNumber,pd.check_number as checkNumber, "
                     + " pd.receipt_number as receiptNumber, pd.bank_number as bankNumber,pd.routing_code as routingCode, "
+                    + " pd.voucher_number as voucherNumber, pd.payment_description as paymentDescription, "
                     + " l.currency_code as currencyCode, l.currency_digits as currencyDigits, l.currency_multiplesof as inMultiplesOf, rc.`name` as currencyName, "
                     + " rc.display_symbol as currencyDisplaySymbol, rc.internationalized_name_code as currencyNameCode, "
                     + " pt.value as paymentTypeName, tr.external_id as externalId, tr.office_id as officeId, office.name as officeName, "
@@ -1309,8 +1310,10 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
                     final String routingCode = rs.getString("routingCode");
                     final String receiptNumber = rs.getString("receiptNumber");
                     final String bankNumber = rs.getString("bankNumber");
-                    paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                            bankNumber);
+                    final String voucherNumber = rs.getString("voucherNumber");
+                    final String paymentDescription = rs.getString("paymentDescription");
+;                    paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
+                            bankNumber,voucherNumber,paymentDescription);
                 }
             }
             final LocalDate date = JdbcSupport.getLocalDate(rs, "date");

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/PaymentDetailConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/PaymentDetailConstants.java
@@ -33,7 +33,9 @@ public class PaymentDetailConstants {
     public static final String checkNumberParamName = "checkNumber";
     public static final String routingCodeParamName = "routingCode";
     public static final String receiptNumberParamName = "receiptNumber";
-    public static final String bankNumberParamName = "bankNumber";
+    public static final String bankNumberParamName = "bankNumber"; 
+    public static final String voucherNumberParamName = "voucherNumber";
+    public static final String paymentDescriptionParamName = "paymentDescription";
 
     // template related part of response
     public static final String officeOptionsParamName = "paymentTypeOptions";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/data/PaymentDetailData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/data/PaymentDetailData.java
@@ -42,12 +42,14 @@ public class PaymentDetailData {
     @SuppressWarnings("unused")
     private final String voucherNumber;
     @SuppressWarnings("unused")
-    private final String paymentDescription;
-
+    private final String paymentDescription; 
 
 
     public PaymentDetailData(final Long id, final PaymentTypeData paymentType, final String accountNumber, final String checkNumber,
-            final String routingCode, final String receiptNumber, final String bankNumber,final String voucherNumber, final String paymentDescription) {
+        final String routingCode, final String receiptNumber, final String bankNumber,final String voucherNumber, 
+        final String paymentDescription) { 
+
+
         this.id = id;
         this.paymentType = paymentType;
         this.accountNumber = accountNumber;
@@ -57,8 +59,22 @@ public class PaymentDetailData {
         this.bankNumber = bankNumber;
         this.voucherNumber = voucherNumber;
         this.paymentDescription = paymentDescription;
-    }
+    } 
+
     
-    
+    public PaymentDetailData(final Long id, final PaymentTypeData paymentType, final String accountNumber, final String checkNumber,
+        final String routingCode, final String receiptNumber, final String bankNumber) { 
+       
+
+        this.id = id;
+        this.paymentType = paymentType;
+        this.accountNumber = accountNumber;
+        this.checkNumber = checkNumber;
+        this.routingCode = routingCode;
+        this.receiptNumber = receiptNumber;
+        this.bankNumber = bankNumber;
+        this.voucherNumber = "";
+        this.paymentDescription = "";
+    } 
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/data/PaymentDetailData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/data/PaymentDetailData.java
@@ -40,14 +40,13 @@ public class PaymentDetailData {
     @SuppressWarnings("unused")
     private final String bankNumber; 
     @SuppressWarnings("unused")
-    private final String voucherNumber;
+    private String voucherNumber;
     @SuppressWarnings("unused")
-    private final String paymentDescription; 
+    private String paymentDescription; 
 
 
     public PaymentDetailData(final Long id, final PaymentTypeData paymentType, final String accountNumber, final String checkNumber,
-        final String routingCode, final String receiptNumber, final String bankNumber,final String voucherNumber, 
-        final String paymentDescription) { 
+        final String routingCode, final String receiptNumber, final String bankNumber) { 
 
 
         this.id = id;
@@ -57,24 +56,16 @@ public class PaymentDetailData {
         this.routingCode = routingCode;
         this.receiptNumber = receiptNumber;
         this.bankNumber = bankNumber;
-        this.voucherNumber = voucherNumber;
-        this.paymentDescription = paymentDescription;
     } 
 
     
     public PaymentDetailData(final Long id, final PaymentTypeData paymentType, final String accountNumber, final String checkNumber,
-        final String routingCode, final String receiptNumber, final String bankNumber) { 
+        final String routingCode, final String receiptNumber, final String bankNumber,final String voucherNumber, final String paymentDescription) { 
        
 
-        this.id = id;
-        this.paymentType = paymentType;
-        this.accountNumber = accountNumber;
-        this.checkNumber = checkNumber;
-        this.routingCode = routingCode;
-        this.receiptNumber = receiptNumber;
-        this.bankNumber = bankNumber;
-        this.voucherNumber = "";
-        this.paymentDescription = "";
+       this(id,paymentType,accountNumber,checkNumber,routingCode,receiptNumber,bankNumber);
+       this.voucherNumber = voucherNumber;
+       this.paymentDescription = paymentDescription;
     } 
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/data/PaymentDetailData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/data/PaymentDetailData.java
@@ -38,10 +38,16 @@ public class PaymentDetailData {
     @SuppressWarnings("unused")
     private final String receiptNumber;
     @SuppressWarnings("unused")
-    private final String bankNumber;
+    private final String bankNumber; 
+    @SuppressWarnings("unused")
+    private final String voucherNumber;
+    @SuppressWarnings("unused")
+    private final String paymentDescription;
+
+
 
     public PaymentDetailData(final Long id, final PaymentTypeData paymentType, final String accountNumber, final String checkNumber,
-            final String routingCode, final String receiptNumber, final String bankNumber) {
+            final String routingCode, final String receiptNumber, final String bankNumber,final String voucherNumber, final String paymentDescription) {
         this.id = id;
         this.paymentType = paymentType;
         this.accountNumber = accountNumber;
@@ -49,6 +55,8 @@ public class PaymentDetailData {
         this.routingCode = routingCode;
         this.receiptNumber = receiptNumber;
         this.bankNumber = bankNumber;
+        this.voucherNumber = voucherNumber;
+        this.paymentDescription = paymentDescription;
     }
     
     

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
@@ -103,10 +103,27 @@ public final class PaymentDetail extends AbstractPersistableCustom<Long> {
         return paymentDetail;
     }
 
+
+    public static PaymentDetail instance(final PaymentType paymentType, final String accountNumber, final String checkNumber,
+            final String routingCode, final String receiptNumber, final String bankNumber) {
+        return new PaymentDetail(paymentType, accountNumber, checkNumber, routingCode, receiptNumber, bankNumber);
+    }
+
+
     public static PaymentDetail instance(final PaymentType paymentType, final String accountNumber, final String checkNumber,
             final String routingCode, final String receiptNumber, final String bankNumber, final String voucherNumber, final String paymentDescription) {
         return new PaymentDetail(paymentType, accountNumber, checkNumber, routingCode, receiptNumber, bankNumber, voucherNumber, paymentDescription);
     }
+
+    private PaymentDetail(final PaymentType paymentType, final String accountNumber, final String checkNumber, final String routingCode,
+            final String receiptNumber, final String bankNumber) {
+        this.paymentType = paymentType;
+        this.accountNumber = accountNumber;
+        this.checkNumber = checkNumber;
+        this.routingCode = routingCode;
+        this.receiptNumber = receiptNumber;
+        this.bankNumber = bankNumber;
+    } 
 
     private PaymentDetail(final PaymentType paymentType, final String accountNumber, final String checkNumber, final String routingCode,
             final String receiptNumber, final String bankNumber, final String voucherNumber, final String paymentDescription) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
@@ -55,7 +55,13 @@ public final class PaymentDetail extends AbstractPersistableCustom<Long> {
     private String receiptNumber;
 
     @Column(name = "bank_number", length = 50)
-    private String bankNumber;
+    private String bankNumber; 
+
+    @Column(name = "voucher_number", length = 50)
+    private String voucherNumber; 
+
+    @Column(name = "payment_description" length = 500)
+    private String paymentDescription;
 
     protected PaymentDetail() {
 
@@ -67,7 +73,9 @@ public final class PaymentDetail extends AbstractPersistableCustom<Long> {
         final String checkNumber = command.stringValueOfParameterNamed(PaymentDetailConstants.checkNumberParamName);
         final String routingCode = command.stringValueOfParameterNamed(PaymentDetailConstants.routingCodeParamName);
         final String receiptNumber = command.stringValueOfParameterNamed(PaymentDetailConstants.receiptNumberParamName);
-        final String bankNumber = command.stringValueOfParameterNamed(PaymentDetailConstants.bankNumberParamName);
+        final String bankNumber = command.stringValueOfParameterNamed(PaymentDetailConstants.bankNumberParamName); 
+        final String voucherNumber = command.stringValueOfParameterNamed(PaymentDetailConstants.voucherNumberParamName);
+        final String paymentDescription = command.stringValueOfParameterNamed(PaymentDetailConstants.paymentDescriptionParamName);
 
         if (StringUtils.isNotBlank(accountNumber)) {
             changes.put(PaymentDetailConstants.accountNumberParamName, accountNumber);
@@ -83,31 +91,39 @@ public final class PaymentDetail extends AbstractPersistableCustom<Long> {
         }
         if (StringUtils.isNotBlank(bankNumber)) {
             changes.put(PaymentDetailConstants.bankNumberParamName, bankNumber);
+        } 
+        if(StringUtils.isNotBlank(voucherNumber)){
+            changes.put(PaymentDetailConstants.voucherNumberParamName, voucherNumber);
+        }
+        if(StringUtils.isNotBlank(paymentDescription)){
+            changes.put(PaymentDetailConstants.paymentDescriptionParamName, paymentDescription);
         }
         final PaymentDetail paymentDetail = new PaymentDetail(paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                bankNumber);
+                bankNumber,voucherNumber, paymentDescription);
         return paymentDetail;
     }
 
     public static PaymentDetail instance(final PaymentType paymentType, final String accountNumber, final String checkNumber,
-            final String routingCode, final String receiptNumber, final String bankNumber) {
-        return new PaymentDetail(paymentType, accountNumber, checkNumber, routingCode, receiptNumber, bankNumber);
+            final String routingCode, final String receiptNumber, final String bankNumber, final String voucherNumber, final String paymentDescription) {
+        return new PaymentDetail(paymentType, accountNumber, checkNumber, routingCode, receiptNumber, bankNumber, voucherNumber, paymentDescription);
     }
 
     private PaymentDetail(final PaymentType paymentType, final String accountNumber, final String checkNumber, final String routingCode,
-            final String receiptNumber, final String bankNumber) {
+            final String receiptNumber, final String bankNumber, final String voucherNumber, final String paymentDescription) {
         this.paymentType = paymentType;
         this.accountNumber = accountNumber;
         this.checkNumber = checkNumber;
         this.routingCode = routingCode;
         this.receiptNumber = receiptNumber;
         this.bankNumber = bankNumber;
+        this.voucherNumber = voucherNumber;
+        this.paymentDescription = paymentDescription;
     }
 
     public PaymentDetailData toData() {
         final PaymentTypeData paymentTypeData = this.paymentType.toData();
         final PaymentDetailData paymentDetailData = new PaymentDetailData(getId(), paymentTypeData, this.accountNumber, this.checkNumber,
-                this.routingCode, this.receiptNumber, this.bankNumber);
+                this.routingCode, this.receiptNumber, this.bankNumber, this.voucherNumber, this.paymentDescription);
         return paymentDetailData;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
@@ -127,12 +127,7 @@ public final class PaymentDetail extends AbstractPersistableCustom<Long> {
 
     private PaymentDetail(final PaymentType paymentType, final String accountNumber, final String checkNumber, final String routingCode,
             final String receiptNumber, final String bankNumber, final String voucherNumber, final String paymentDescription) {
-        this.paymentType = paymentType;
-        this.accountNumber = accountNumber;
-        this.checkNumber = checkNumber;
-        this.routingCode = routingCode;
-        this.receiptNumber = receiptNumber;
-        this.bankNumber = bankNumber;
+        this(paymentType,accountNumber,checkNumber,routingCode,receiptNumber,bankNumber);
         this.voucherNumber = voucherNumber;
         this.paymentDescription = paymentDescription;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetail.java
@@ -60,7 +60,7 @@ public final class PaymentDetail extends AbstractPersistableCustom<Long> {
     @Column(name = "voucher_number", length = 50)
     private String voucherNumber; 
 
-    @Column(name = "payment_description" length = 500)
+    @Column(name = "payment_description", length = 500)
     private String paymentDescription;
 
     protected PaymentDetail() {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetailAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/paymentdetail/domain/PaymentDetailAssembler.java
@@ -49,7 +49,9 @@ public class PaymentDetailAssembler {
         final String checkNumber = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.checkNumberParamName, json);
         final String routingCode = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.routingCodeParamName, json);
         final String receiptNumber = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.receiptNumberParamName, json);
-        final String bankNumber = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.bankNumberParamName, json);
-        return PaymentDetail.instance(paymentType, accountNumber, checkNumber, routingCode, receiptNumber, bankNumber);
+        final String bankNumber = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.bankNumberParamName, json); 
+        final String voucherNumber = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.voucherNumberParamName, json);
+        final String paymentDescription = this.fromApiJsonHelper.extractStringNamed(PaymentDetailConstants.paymentDescriptionParamName, json);
+        return PaymentDetail.instance(paymentType, accountNumber, checkNumber, routingCode, receiptNumber, bankNumber, voucherNumber, paymentDescription);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
@@ -109,6 +109,8 @@ public class DepositsApiConstants {
     public static final String routingCodeParamName = "routingCode";
     public static final String receiptNumberParamName = "receiptNumber";
     public static final String bankNumberParamName = "bankNumber";
+    public static final String voucherNumberParamName = "voucherNumber";
+    public static final String paymentDescriptionParamName = "paymentDescription";
 
     // Preclosure parameters
     public static final String preClosurePenalApplicableParamName = "preClosurePenalApplicable";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
@@ -134,7 +134,10 @@ public class SavingsApiConstants {
     public static final String withdrawBalanceParamName = "withdrawBalance";
     public static final String onHoldFundsParamName = "onHoldFunds";
     public static final String withHoldTaxParamName = "withHoldTax";
-    public static final String taxGroupIdParamName = "taxGroupId";
+    public static final String taxGroupIdParamName = "taxGroupId"; 
+    public static final String voucherNumberParamName = "voucherNumber";
+    public static final String paymentDescriptionParamName = "paymentDescription";
+
 
     // transaction parameters
     public static final String transactionDateParamName = "transactionDate";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/DepositAccountTransactionDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/DepositAccountTransactionDataValidator.java
@@ -30,6 +30,10 @@ import static org.apache.fineract.portfolio.savings.DepositsApiConstants.toSavin
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.transactionAccountNumberParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.transactionAmountParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.transactionDateParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.voucherNumberParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.paymentDescriptionParamName;
+
+
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -66,7 +70,7 @@ public class DepositAccountTransactionDataValidator {
 	private static final Set<String> DEPOSIT_ACCOUNT_TRANSACTION_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(
 			DepositsApiConstants.localeParamName, DepositsApiConstants.dateFormatParamName, transactionDateParamName,
 			transactionAmountParamName, paymentTypeIdParamName, transactionAccountNumberParamName, checkNumberParamName,
-			routingCodeParamName, receiptNumberParamName, bankNumberParamName));
+			routingCodeParamName, receiptNumberParamName, bankNumberParamName,voucherNumberParamName,paymentDescriptionParamName));
 
 	private static final Set<String> DEPOSIT_ACCOUNT_RECOMMENDED_DEPOSIT_AMOUNT_UPDATE_REQUEST_DATA_PARAMETERS = new HashSet<>(
 			Arrays.asList(DepositsApiConstants.localeParamName, DepositsApiConstants.dateFormatParamName,
@@ -77,7 +81,8 @@ public class DepositAccountTransactionDataValidator {
 			DepositsApiConstants.localeParamName, DepositsApiConstants.dateFormatParamName, closedOnDateParamName,
 			DepositsApiConstants.noteParamName, onAccountClosureIdParamName, paymentTypeIdParamName,
 			transactionAccountNumberParamName, checkNumberParamName, routingCodeParamName, receiptNumberParamName,
-			bankNumberParamName, DepositsApiConstants.transferDescriptionParamName, toSavingsAccountIdParamName));
+			bankNumberParamName, DepositsApiConstants.transferDescriptionParamName, toSavingsAccountIdParamName,
+            voucherNumberParamName,paymentDescriptionParamName));
 
 	private static final Set<String> DEPOSIT_ACCOUNT_PRE_MATURE_CALCULATION_REQUEST_DATA_PARAMETERS = new HashSet<>(
 			Arrays.asList(DepositsApiConstants.localeParamName, DepositsApiConstants.dateFormatParamName,
@@ -115,7 +120,7 @@ public class DepositAccountTransactionDataValidator {
         final Integer paymentTypeId = this.fromApiJsonHelper.extractIntegerWithLocaleNamed(paymentTypeIdParamName, element);
         baseDataValidator.reset().parameter(paymentTypeIdParamName).value(paymentTypeId).ignoreIfNull().integerGreaterThanZero();
         final Set<String> paymentDetailParameters = new HashSet<>(Arrays.asList(transactionAccountNumberParamName, checkNumberParamName,
-                routingCodeParamName, receiptNumberParamName, bankNumberParamName));
+                routingCodeParamName, receiptNumberParamName, bankNumberParamName,voucherNumberParamName,paymentDescriptionParamName));
         for (final String paymentDetailParameterName : paymentDetailParameters) {
             final String paymentDetailParameterValue = this.fromApiJsonHelper.extractStringNamed(paymentDetailParameterName, element);
             baseDataValidator.reset().parameter(paymentDetailParameterName).value(paymentDetailParameterValue).ignoreIfNull()
@@ -234,7 +239,7 @@ public class DepositAccountTransactionDataValidator {
         final Integer paymentTypeId = this.fromApiJsonHelper.extractIntegerWithLocaleNamed(paymentTypeIdParamName, element);
         baseDataValidator.reset().parameter(paymentTypeIdParamName).value(paymentTypeId).ignoreIfNull().integerGreaterThanZero();
         final Set<String> paymentDetailParameters = new HashSet<>(Arrays.asList(transactionAccountNumberParamName, checkNumberParamName,
-                routingCodeParamName, receiptNumberParamName, bankNumberParamName));
+                routingCodeParamName, receiptNumberParamName, bankNumberParamName,voucherNumberParamName,paymentDescriptionParamName));
         for (final String paymentDetailParameterName : paymentDetailParameters) {
             final String paymentDetailParameterValue = this.fromApiJsonHelper.extractStringNamed(paymentDetailParameterName, element);
             baseDataValidator.reset().parameter(paymentDetailParameterName).value(paymentDetailParameterValue).ignoreIfNull()

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
@@ -53,7 +53,8 @@ public class SavingsAccountConstant extends SavingsApiConstants {
 	protected static final Set<String> SAVINGS_ACCOUNT_TRANSACTION_REQUEST_DATA_PARAMETERS = new HashSet<>(
 			Arrays.asList(localeParamName, dateFormatParamName, transactionDateParamName, transactionAmountParamName,
 					paymentTypeIdParamName, transactionAccountNumberParamName, checkNumberParamName,
-					routingCodeParamName, receiptNumberParamName, bankNumberParamName));
+					routingCodeParamName, receiptNumberParamName, bankNumberParamName,voucherNumberParamName,
+					paymentDescriptionParamName));
 
 	protected static final Set<String> SAVINGS_ACCOUNT_TRANSACTION_RESPONSE_DATA_PARAMETERS = new HashSet<>(
 			Arrays.asList(idParamName, accountNoParamName));
@@ -64,7 +65,8 @@ public class SavingsAccountConstant extends SavingsApiConstants {
 	protected static final Set<String> SAVINGS_ACCOUNT_CLOSE_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(
 			localeParamName, dateFormatParamName, closedOnDateParamName, noteParamName, paymentTypeIdParamName,
 			withdrawBalanceParamName, transactionAccountNumberParamName, checkNumberParamName, routingCodeParamName,
-			receiptNumberParamName, bankNumberParamName, postInterestValidationOnClosure));
+			receiptNumberParamName, bankNumberParamName, postInterestValidationOnClosure,
+			bankNumberParamName,voucherNumberParamName));
 
 	protected static final Set<String> SAVINGS_ACCOUNT_CHARGES_ADD_REQUEST_DATA_PARAMETERS = new HashSet<>(
 			Arrays.asList(chargeIdParamName, amountParamName, dueAsOfDateParamName, dateFormatParamName,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
@@ -159,7 +159,7 @@ public class SavingsAccountTransactionDataValidator {
         final Integer paymentTypeId = this.fromApiJsonHelper.extractIntegerWithLocaleNamed(paymentTypeIdParamName, element);
         baseDataValidator.reset().parameter(paymentTypeIdParamName).value(paymentTypeId).ignoreIfNull().integerGreaterThanZero();
         final Set<String> paymentDetailParameters = new HashSet<>(Arrays.asList(transactionAccountNumberParamName, checkNumberParamName,
-                routingCodeParamName, receiptNumberParamName, bankNumberParamName));
+                routingCodeParamName, receiptNumberParamName, bankNumberParamName,voucherNumberParamName,paymentDescriptionParamName));
         for (final String paymentDetailParameterName : paymentDetailParameters) {
             final String paymentDetailParameterValue = this.fromApiJsonHelper.extractStringNamed(paymentDetailParameterName, element);
             baseDataValidator.reset().parameter(paymentDetailParameterName).value(paymentDetailParameterValue).ignoreIfNull()

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountTransactionDataValidator.java
@@ -30,7 +30,11 @@ import static org.apache.fineract.portfolio.savings.SavingsApiConstants.transact
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.transactionDateParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.withdrawBalanceParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.SAVINGS_ACCOUNT_HOLD_AMOUNT_REQUEST_DATA_PARAMETERS;
-import static org.apache.fineract.portfolio.savings.SavingsApiConstants.SAVINGS_ACCOUNT_RESOURCE_NAME;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.SAVINGS_ACCOUNT_RESOURCE_NAME; 
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.voucherNumberParamName;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.paymentDescriptionParamName;
+
+
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
@@ -970,6 +970,8 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
             sqlBuilder.append("sa.id as savingsId, sa.account_no as accountNo,");
             sqlBuilder.append("pd.payment_type_id as paymentType,pd.account_number as accountNumber,pd.check_number as checkNumber, ");
             sqlBuilder.append("pd.receipt_number as receiptNumber, pd.bank_number as bankNumber,pd.routing_code as routingCode, ");
+            sqlBuilder.append("pd.voucher_number as voucherNumber, pd.payment_description as paymentDescription, ");
+
             sqlBuilder
                     .append("sa.currency_code as currencyCode, sa.currency_digits as currencyDigits, sa.currency_multiplesof as inMultiplesOf, ");
             sqlBuilder.append("curr.name as currencyName, curr.internationalized_name_code as currencyNameCode, ");
@@ -1016,8 +1018,13 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
                     final String routingCode = rs.getString("routingCode");
                     final String receiptNumber = rs.getString("receiptNumber");
                     final String bankNumber = rs.getString("bankNumber");
+                    final String voucherNumber = rs.getString("voucherNumber");
+                    final String paymentDescription = rs.getString("paymentDescription");
+
+
+
                     paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                            bankNumber);
+                            bankNumber,voucherNumber,paymentDescription);
                 }
             }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
@@ -784,6 +784,8 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
             sqlBuilder.append("sa.id as savingsId, sa.account_no as accountNo,");
             sqlBuilder.append("pd.payment_type_id as paymentType,pd.account_number as accountNumber,pd.check_number as checkNumber, ");
             sqlBuilder.append("pd.receipt_number as receiptNumber, pd.bank_number as bankNumber,pd.routing_code as routingCode, ");
+            sqlBuilder.append("pd.voucher_number as voucherNumber, pd.payment_description as paymentDescription, ");
+
             sqlBuilder
                     .append("sa.currency_code as currencyCode, sa.currency_digits as currencyDigits, sa.currency_multiplesof as inMultiplesOf, ");
             sqlBuilder.append("curr.name as currencyName, curr.internationalized_name_code as currencyNameCode, ");
@@ -833,6 +835,11 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
                     final String routingCode = rs.getString("routingCode");
                     final String receiptNumber = rs.getString("receiptNumber");
                     final String bankNumber = rs.getString("bankNumber");
+                    final String voucherNumber = rs.getString("voucherNumber");
+                    final String paymentDescription = rs.getString("paymentDescription");
+
+
+
                     paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
                             bankNumber);
                 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
@@ -841,7 +841,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
 
 
                     paymentDetailData = new PaymentDetailData(id, paymentType, accountNumber, checkNumber, routingCode, receiptNumber,
-                            bankNumber);
+                            bankNumber,voucherNumber,paymentDescription);
                 }
             }
 

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
@@ -16,5 +16,5 @@
 -- specific language governing permissions and limitations
 -- under the License.
 --
-ALTER TABLE `m_payment_detail` ADD COLUMN `voucher_number` BIGINT(20) NULL DEFAULT NULL;
+ALTER TABLE `m_payment_detail` ADD COLUMN `voucher_number` VARCHAR(100) NULL DEFAULT NULL;
 ALTER TABLE `m_payment_detail` ADD COLUMN `payment_description` VARCHAR(1000) NULL DEFAULT NULL;

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
@@ -1,0 +1,22 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+ALTER TABLE `m_payment_details`
+ADD COLUMN `voucher_number` BIGINT(20) NULL DEFAULT NULL,
+ADD COLUMN 'payment_description'  VARCHAR(1000) NULL DEFAULT NULL;

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
@@ -16,5 +16,6 @@
 -- specific language governing permissions and limitations
 -- under the License.
 --
+
 ALTER TABLE `m_payment_detail` ADD COLUMN `voucher_number` VARCHAR(100) NULL DEFAULT NULL;
 ALTER TABLE `m_payment_detail` ADD COLUMN `payment_description` VARCHAR(1000) NULL DEFAULT NULL;

--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V7001__payment_details_and_voucher_number_for_all_transactions.sql
@@ -16,7 +16,5 @@
 -- specific language governing permissions and limitations
 -- under the License.
 --
-
-ALTER TABLE `m_payment_details`
-ADD COLUMN `voucher_number` BIGINT(20) NULL DEFAULT NULL,
-ADD COLUMN 'payment_description'  VARCHAR(1000) NULL DEFAULT NULL;
+ALTER TABLE `m_payment_detail` ADD COLUMN `voucher_number` BIGINT(20) NULL DEFAULT NULL;
+ALTER TABLE `m_payment_detail` ADD COLUMN `payment_description` VARCHAR(1000) NULL DEFAULT NULL;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Two fields have been added to all loan repayments, savings deposits and withdrawals: a voucherNumber and a paymentDescription
Current behavior before PR:
There were no fields for adding a voucher number or payment description to loan repayments, savings deposits or withdrawals.
Desired behavior after PR is merged:
The client can record the voucher number and paymentDescription of loan repayments, savings deposits and withdrawals.

--
